### PR TITLE
min size adjustment for side panel

### DIFF
--- a/src/js/components/SplitLayout.jsx
+++ b/src/js/components/SplitLayout.jsx
@@ -14,7 +14,7 @@ class SplitLayout extends React.Component{
         this.state = {
             currentSize: 200,
             maxSize: 200,
-            minSize: 50,
+            minSize: 100,
             fixed: false,
             collapsed: false,
             dragging: false,


### PR DESCRIPTION
When min-size was applied, the sidebar was overlapping the panel resizer. Doubled the min-width to resolve the issue.