### PR TITLE
CSS Update to Settings-item

### DIFF
--- a/src/js/components/react-components/src/sidebar/sidebar.scss
+++ b/src/js/components/react-components/src/sidebar/sidebar.scss
@@ -4,7 +4,7 @@
     padding: 10px;
     bottom: 0;
     right: 0;
-    z-index: 10;
+    z-index: 20;
     width: 100%;
     background: white;
     border-top: 1px solid #D8D8D8;

--- a/src/js/components/react-components/src/sidebar/sidebar.scss
+++ b/src/js/components/react-components/src/sidebar/sidebar.scss
@@ -1,11 +1,13 @@
 @import '../theme/colors';
 .settings-item{
     position: absolute;
-    padding-left: 10px;
-    bottom: 10px;
+    padding: 10px;
+    bottom: 0;
     right: 0;
     z-index: 10;
     width: 100%;
+    background: white;
+    border-top: 1px solid #D8D8D8;
     &.collapsed{
         right: -1px;
         .dropdown-toggle:after{


### PR DESCRIPTION
When logged in, settings view item (bottom left) overlaps the timeline visually. To correct this, I have added a background, padding, and also a border-top.